### PR TITLE
Allow Hatchet orchestration in document summary backfill

### DIFF
--- a/py/scripts/backfill_document_summaries.py
+++ b/py/scripts/backfill_document_summaries.py
@@ -34,6 +34,20 @@ def _chunk_records_to_dicts(results: list[dict]) -> list[dict]:
 async def backfill_document_summaries() -> None:
     """Generate and store summaries for documents lacking one."""
     config = R2RConfig.load()
+    # `backfill_document_summaries` runs as a one-off maintenance script and
+    # does not require the distributed Hatchet orchestrator. Some config
+    # presets (e.g. "full") enable the Hatchet provider by default which in
+    # turn expects the `HATCHET_CLIENT_TOKEN` environment variable to be set.
+    # When the token is absent the script would previously crash during
+    # provider creation. Fallback to the lightweight "simple" orchestration
+    # provider unless the token is available so Hatchet can be used when
+    # desired.
+    if not os.getenv("HATCHET_CLIENT_TOKEN"):
+        logger.info(
+            "HATCHET_CLIENT_TOKEN not set; using simple orchestration provider"
+        )
+        config.orchestration.provider = "simple"
+
     builder = R2RBuilder(config)
     app = await builder.build()
 


### PR DESCRIPTION
## Summary
- Use Hatchet orchestration in backfill_document_summaries when `HATCHET_CLIENT_TOKEN` is set, otherwise fall back to the simple provider

## Testing
- `python3 py/scripts/backfill_document_summaries.py` *(fails: ModuleNotFoundError: asyncpg)*
- `PYTHONPATH=py pytest py/tests/unit/app/test_config.py::test_load_default_config -q` *(fails: ModuleNotFoundError: asyncpg)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fbf62860832a9a01dfb7aa4ee1fe