### PR TITLE
refactor: remove vacuum and delete docs via listing

### DIFF
--- a/py/scripts/delete_files_and_vacuum.py
+++ b/py/scripts/delete_files_and_vacuum.py
@@ -1,17 +1,9 @@
-"""Utility script to purge documents by file type and vacuum the database.
+"""Utility script to purge documents by file type.
 
-The script iterates over a set of file extensions, deletes all documents of each
-extension using the REST API, and finally triggers a database vacuum. Example
-API call for deleting all `.xlsx` files:
-
-```
-curl -X DELETE 'http://localhost:7272/v3/documents/by-filter' \
-    -H 'Content-Type: application/json' \
-    -d '{"document_type": {"$eq": "xlsx"}}'
-```
-
-The vacuum endpoint assumes a maintenance route is exposed at
-`POST /v3/maintenance/vacuum`.
+The script iterates over a set of file extensions, lists all documents of each
+extension using the Python client, and deletes each document individually. This
+avoids the need for API-key based endpoints and removes the previous database
+vacuum step.
 """
 
 import logging
@@ -60,30 +52,37 @@ logger = logging.getLogger(__name__)
 
 def delete_documents_by_type(client: R2RClient, file_types: Sequence[str]) -> None:
     """Delete all documents matching the provided file extensions."""
+
     for file_type in file_types:
         try:
             logger.info("Deleting documents of type %s", file_type)
-            client.documents.delete_by_filter(
-                filters={"document_type": {"$eq": file_type}}
-            )
+            offset = 0
+            ids: list[str] = []
+            while True:
+                resp = client.documents.list(offset=offset, limit=1000)
+                documents = resp.results or []
+                if not documents:
+                    break
+                ids.extend(
+                    str(doc.id)
+                    for doc in documents
+                    if doc.document_type.value == file_type
+                )
+                offset += len(documents)
+
+            for doc_id in ids:
+                try:
+                    client.documents.delete(doc_id)
+                except Exception as exc:  # pragma: no cover - best effort logging
+                    logger.error("Failed to delete document %s: %s", doc_id, exc)
         except Exception as exc:  # pragma: no cover - best effort logging
             logger.error("Failed to delete type %s: %s", file_type, exc)
-
-
-def vacuum_database(client: R2RClient) -> None:
-    """Trigger a database vacuum via the maintenance API."""
-    try:
-        client._make_request("POST", "maintenance/vacuum", version="v3")
-        logger.info("Vacuum triggered successfully")
-    except Exception as exc:  # pragma: no cover - best effort logging
-        logger.error("Vacuum request failed: %s", exc)
 
 
 def main() -> None:
     base_url = os.getenv("R2R_BASE_URL", "http://localhost:7272")
     client = R2RClient(base_url=base_url)
     delete_documents_by_type(client, FILE_TYPES)
-    vacuum_database(client)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- delete documents by listing and removing each ID
- drop vacuum call from maintenance script

## Testing
- `ruff check py/scripts/delete_files_and_vacuum.py --fix`
- `PYTHONPATH=py pytest py/tests/unit -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b2e32eda04832a9888dac20049e08e