### PR TITLE
feat: add dry run to duplicate document removal

### DIFF
--- a/py/scripts/remove_duplicate_documents.py
+++ b/py/scripts/remove_duplicate_documents.py
@@ -4,6 +4,7 @@ The script fetches all documents from the database, groups them by the
 `metadata['sha256']` field and deletes all but one document for each hash.
 """
 
+import argparse
 import asyncio
 import logging
 import os
@@ -19,8 +20,13 @@ from core.main.config import R2RConfig
 logger = logging.getLogger(__name__)
 
 
-async def remove_duplicate_documents() -> None:
-    """Delete duplicate documents sharing the same SHA-256 hash."""
+async def remove_duplicate_documents(commit: bool = False) -> None:
+    """Delete duplicate documents sharing the same SHA-256 hash.
+
+    When ``commit`` is ``False`` (the default), the function logs the
+    duplicates it would delete without removing them. Pass ``commit=True`` to
+    actually delete the duplicates.
+    """
     config = R2RConfig.load()
     if not os.getenv("HATCHET_CLIENT_TOKEN"):
         logger.info(
@@ -51,12 +57,31 @@ async def remove_duplicate_documents() -> None:
             seen[sha256] = doc
 
     for doc in duplicates:
-        logger.info("Deleting duplicate document %s", doc.id)
-        await providers.database.documents_handler.delete(doc.id, doc.version)
+        if commit:
+            logger.info("Deleting duplicate document %s", doc.id)
+            await providers.database.documents_handler.delete(doc.id, doc.version)
+        else:
+            logger.info("Would delete duplicate document %s", doc.id)
 
-    logger.info("Deleted %d duplicate documents", len(duplicates))
+    if commit:
+        logger.info("Deleted %d duplicate documents", len(duplicates))
+    else:
+        logger.info(
+            "Found %d duplicate documents; run with --commit to delete",
+            len(duplicates),
+        )
+
     await providers.database.close()
 
 
 if __name__ == "__main__":
-    asyncio.run(remove_duplicate_documents())
+    parser = argparse.ArgumentParser(
+        description="Remove duplicate documents based on metadata SHA-256 hash",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually delete duplicate documents instead of performing a dry run",
+    )
+    args = parser.parse_args()
+    asyncio.run(remove_duplicate_documents(commit=args.commit))


### PR DESCRIPTION
## Summary
- add optional `--commit` flag to remove_duplicate_documents script and default to dry run

## Testing
- `ruff check py/scripts/remove_duplicate_documents.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68b5416009f0832a990edc564d79c9aa